### PR TITLE
Support IDEA 2022.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,12 +3,12 @@
 
 pluginGroup = com.github.fantom.codeowners
 pluginName = CODEOWNERS
-pluginVersion = 0.3.4
+pluginVersion = 0.3.5
 pluginSinceBuild = 212
-pluginUntilBuild = 221.*
+pluginUntilBuild = 222.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2022.1
+pluginVerifierIdeVersions = 2022.2
 
 platformType = IC
 platformVersion = 2021.2


### PR DESCRIPTION
Works with IntelliJ IDEA 2022.2 EAP (Ultimate Edition)
Build #IU-222.3244.4, built on June 29, 2022
