### PR TITLE
Implement search scope, based on file ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## Unreleased
 
+### Added
+- Implement ownership-based search scope: build an ownership predicate in a DNF and filter files during search
+
 ## [v0.6.0](https://github.com/fan-tom/intellij-codeowners/tree/v0.6.0) (2023-08-13)
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -118,7 +118,7 @@ koverReport {
 tasks {
     listOf("compileKotlin", "compileTestKotlin").forEach {
         getByName<KotlinCompile>(it) {
-            kotlinOptions.freeCompilerArgs = listOf("-Xinline-classes")
+            kotlinOptions.freeCompilerArgs = listOf("-Xinline-classes", "-Xcontext-receivers")
 
             dependsOn(generateGithubLexer, generateGithubParser, generateBitbucketLexer, generateBitbucketParser)
         }

--- a/src/main/kotlin/com/github/fantom/codeowners/CodeownersManager.kt
+++ b/src/main/kotlin/com/github/fantom/codeowners/CodeownersManager.kt
@@ -179,14 +179,14 @@ class CodeownersManager(private val project: Project) : DumbAware, Disposable {
     }
 
     /**
-     * @return: list of CODEOWNERS files that can assign owners to given file.
-     * Might be no equal to the list of all existing CODEOWNERS files i.e. in case of local overrides for Bitbucket
+     * @return a list of CODEOWNERS files that can assign owners to the given [file].
+     * Might be not equal to the list of all existing CODEOWNERS files i.e. in case of local overrides for Bitbucket
      */
     @Suppress("UnusedPrivateMember")
     fun getApplicableCodeownersFiles(file: VirtualFile): Map<CodeownersFileType, List<CodeownersEntryOccurrence>> {
         // TODO handle actual overrides
         return FILE_TYPES
-            .mapNotNull { ty -> cachedCodeownersFilesIndex[ty]?.let { Pair(ty, it) } }
+            .map { ty -> Pair(ty, cachedCodeownersFilesIndex[ty]) }
             .associate { it }
     }
 

--- a/src/main/kotlin/com/github/fantom/codeowners/CodeownersManager.kt
+++ b/src/main/kotlin/com/github/fantom/codeowners/CodeownersManager.kt
@@ -191,6 +191,19 @@ class CodeownersManager(private val project: Project) : DumbAware, Disposable {
     }
 
     /**
+     * Return all known CODEOWNERS files
+     */
+    fun getCodeownersFiles(): List<CodeownersEntryOccurrence> = cachedCodeownersFilesIndex[CodeownersFileType.INSTANCE]
+
+    // TODO make type-specific? Bitbucket teams are declared in the file
+    fun getMentionedOwners(codeownersFile: CodeownersEntryOccurrence): Set<OwnerString> {
+        return codeownersFile.items
+            .asSequence()
+            .flatMap { (_, owners) -> owners.owners.asSequence() }
+            .toSet()
+    }
+
+    /**
      * Checks if file has owners.
      *
      * @param file current file

--- a/src/main/kotlin/com/github/fantom/codeowners/indexing/CodeownersEntryOccurrence.kt
+++ b/src/main/kotlin/com/github/fantom/codeowners/indexing/CodeownersEntryOccurrence.kt
@@ -15,7 +15,11 @@ value class RegexString(val regex: String) {
 }
 
 @JvmInline
-value class OwnerString(val owner: String) {
+value class OwnerString(val owner: String): Comparable<OwnerString> {
+    override fun compareTo(other: OwnerString): Int {
+        return owner.compareTo(other.owner)
+    }
+
     override fun toString() = owner
 }
 

--- a/src/main/kotlin/com/github/fantom/codeowners/indexing/CodeownersEntryOccurrence.kt
+++ b/src/main/kotlin/com/github/fantom/codeowners/indexing/CodeownersEntryOccurrence.kt
@@ -24,7 +24,7 @@ value class OwnerString(val owner: String) {
  * of codeowners entries with line numbers for better performance. Class is used for indexing.
  */
 @Suppress("SerialVersionUIDInSerializableClass")
-class CodeownersEntryOccurrence(private val url: String, val items: List<Pair<RegexString, OwnersReference>>) : Serializable {
+class CodeownersEntryOccurrence(val url: String, val items: List<Pair<RegexString, OwnersReference>>) : Serializable {
 
     /**
      * Returns current [VirtualFile].

--- a/src/main/kotlin/com/github/fantom/codeowners/indexing/CodeownersFilesIndex.kt
+++ b/src/main/kotlin/com/github/fantom/codeowners/indexing/CodeownersFilesIndex.kt
@@ -43,7 +43,7 @@ class CodeownersFilesIndex :
     companion object {
         private val LOGGER = Logger.getInstance(CodeownersFilesIndex::class.java)
         val KEY = ID.create<CodeownersFileType, CodeownersEntryOccurrence>("CodeownersFilesIndex")
-        private const val VERSION = 1
+        private const val VERSION = 2
         private val DATA_EXTERNALIZER = object : DataExternalizer<CodeownersEntryOccurrence> {
 
             @Throws(IOException::class)
@@ -98,9 +98,11 @@ class CodeownersFilesIndex :
 //            }
 //        )
 
-        return Collections.singletonMap(
-            (inputData.fileType as CodeownersFileType),
-            CodeownersEntryOccurrence(inputData.file.url, inputDataPsi.getRulesList())
+        val codeownersEntryOccurrence = CodeownersEntryOccurrence(inputData.file.url, inputDataPsi.getRulesList())
+
+        return mapOf(
+            CodeownersFileType.INSTANCE to codeownersEntryOccurrence,
+            (inputData.fileType as CodeownersFileType) to codeownersEntryOccurrence,
         )
     }
 

--- a/src/main/kotlin/com/github/fantom/codeowners/search/CodeownersSearchFilter.kt
+++ b/src/main/kotlin/com/github/fantom/codeowners/search/CodeownersSearchFilter.kt
@@ -7,6 +7,7 @@ import com.github.fantom.codeowners.indexing.OwnerString
 import com.intellij.openapi.vfs.VirtualFile
 
 interface Predicate {
+    // TODO change to OwnersSet, duplicates make no sense
     fun satisfies(fileOwners: OwnersList?): Boolean
 }
 
@@ -62,6 +63,17 @@ sealed interface Filter: Predicate {
             }
 
             override fun satisfies(fileOwners: OwnersList?) = fileOwners?.containsAll(owners) ?: false
+        }
+
+        // files, owned by only given owners, no extra owners allowed
+        data class OwnedByExactly(val owners: Set<OwnerString>): Condition {
+            override fun displayName() = "owned by exactly ${owners.joinToString(", ")}"
+
+            override fun satisfiable(codeownersFile: CodeownersEntryOccurrence): Boolean {
+                return codeownersFile.items.map { it.second }.any { satisfies(it.owners) }
+            }
+
+            override fun satisfies(fileOwners: OwnersList?) = fileOwners?.let { owners == it.toSet() } ?: false
         }
     }
 

--- a/src/main/kotlin/com/github/fantom/codeowners/search/CodeownersSearchFilter.kt
+++ b/src/main/kotlin/com/github/fantom/codeowners/search/CodeownersSearchFilter.kt
@@ -1,0 +1,105 @@
+package com.github.fantom.codeowners.search
+
+import com.github.fantom.codeowners.CodeownersManager
+import com.github.fantom.codeowners.OwnersList
+import com.github.fantom.codeowners.indexing.CodeownersEntryOccurrence
+import com.github.fantom.codeowners.indexing.OwnerString
+import com.intellij.openapi.vfs.VirtualFile
+
+interface Predicate {
+    fun satisfies(fileOwners: OwnersList?): Boolean
+}
+
+sealed interface Filter: Predicate {
+    fun displayName(): CharSequence
+
+    // TODO rewrite using service + context
+    /**
+     * @return false, if this filter definitely cannot be satisfied by given codeowners file, true otherwise
+     */
+    fun satisfiable(codeownersFile: CodeownersEntryOccurrence): Boolean
+
+    sealed interface Condition: Filter {
+        // files without assigned owners
+        data object Unowned: Condition {
+            override fun displayName() = "unowned"
+
+            override fun satisfiable(codeownersFile: CodeownersEntryOccurrence): Boolean {
+                return true // cannot easily calculate it precise: need to proof there is at least one unowned file
+            }
+
+            override fun satisfies(fileOwners: OwnersList?) = fileOwners == null
+        }
+
+        // explicitly unowned files
+        data object OwnershipReset: Condition {
+            override fun displayName() = "explicitly unowned"
+
+            override fun satisfiable(codeownersFile: CodeownersEntryOccurrence): Boolean {
+                return codeownersFile.items.any { it.second.owners.isEmpty() }
+            }
+
+            override fun satisfies(fileOwners: OwnersList?) = fileOwners?.isEmpty() ?: false
+        }
+
+        // files, owned by any (at least one) of the given owners
+        data class OwnedByAnyOf(val owners: Set<OwnerString>): Condition {
+            override fun displayName() = "owned by any of ${owners.joinToString(", ")}"
+
+            override fun satisfiable(codeownersFile: CodeownersEntryOccurrence): Boolean {
+                return true // because "owners" can be only from this file, so they own some files
+            }
+
+            override fun satisfies(fileOwners: OwnersList?) = fileOwners?.any { it in owners } ?: false
+        }
+
+        // files, owned by all the given owners, and maybe by some extra owners
+        data class OwnedByAllOf(val owners: Set<OwnerString>): Condition {
+            override fun displayName() = "owned by all of ${owners.joinToString(", ")}"
+
+            override fun satisfiable(codeownersFile: CodeownersEntryOccurrence): Boolean {
+                return codeownersFile.items.map { it.second }.any { satisfies(it.owners) }
+            }
+
+            override fun satisfies(fileOwners: OwnersList?) = fileOwners?.containsAll(owners) ?: false
+        }
+    }
+
+    // negation of some Condition
+    data class Not(val condition: Condition): Filter {
+        override fun displayName() = "not ${condition.displayName()}"
+
+        override fun satisfiable(codeownersFile: CodeownersEntryOccurrence): Boolean {
+            // cannot calculate it in abstract: it depends on the nature of the "condition"
+            return true
+        }
+
+        override fun satisfies(fileOwners: OwnersList?): Boolean {
+            return !condition.satisfies(fileOwners)
+        }
+    }
+}
+
+// disjunction of conjunctions
+data class DNF(val filters: List<List<Filter>>): Predicate {
+    override fun satisfies(fileOwners: OwnersList?) = filters.any { conj -> conj.all { n -> n.satisfies(fileOwners) } }
+
+    fun displayName() =
+        filters.joinToString(" or ") { conj -> "(${conj.joinToString(" and ") { n -> n.displayName() }})" }
+}
+
+data class CodeownersSearchFilter(
+    val codeownersFile: CodeownersEntryOccurrence,
+    // DNF: disjunction of conjunctions
+    private val dnf: DNF
+): Predicate by dnf {
+    fun displayName() = "${codeownersFile.url}: ${dnf.displayName()}"
+
+    context(CodeownersManager)
+    fun satisfies(file: VirtualFile): Boolean {
+        val ownersRef = getFileOwners(file, codeownersFile).getOrNull() ?: return false
+        val ownersList = ownersRef.ref?.owners
+
+        return satisfies(ownersList)
+    }
+}

--- a/src/main/kotlin/com/github/fantom/codeowners/search/CodeownersSearchScope.kt
+++ b/src/main/kotlin/com/github/fantom/codeowners/search/CodeownersSearchScope.kt
@@ -1,0 +1,31 @@
+package com.github.fantom.codeowners.search
+
+import com.github.fantom.codeowners.CodeownersIcons
+import com.github.fantom.codeowners.CodeownersManager
+import com.intellij.openapi.components.service
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.search.GlobalSearchScope
+
+
+class CodeownersSearchScope(
+    project: Project,
+    private val filterCtx: CodeownersSearchFilter
+): GlobalSearchScope(project) {
+    private val manager = project.service<CodeownersManager>()
+
+    override fun contains(file: VirtualFile): Boolean {
+        with(manager) {
+            return filterCtx.satisfies(file)
+        }
+    }
+
+    override fun isSearchInModuleContent(aModule: Module) = true
+
+    override fun isSearchInLibraries() = true
+
+    override fun getDisplayName() = filterCtx.displayName()
+
+    override fun getIcon() = CodeownersIcons.FILE
+}

--- a/src/main/kotlin/com/github/fantom/codeowners/search/CodeownersSearchScopeDescriptor.kt
+++ b/src/main/kotlin/com/github/fantom/codeowners/search/CodeownersSearchScopeDescriptor.kt
@@ -1,0 +1,48 @@
+package com.github.fantom.codeowners.search
+
+import com.github.fantom.codeowners.CodeownersBundle
+import com.github.fantom.codeowners.CodeownersIcons
+import com.github.fantom.codeowners.CodeownersManager
+import com.github.fantom.codeowners.search.ui.CodeownersSearchFilterDialog
+import com.intellij.ide.util.scopeChooser.ScopeDescriptor
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.SearchScope
+
+class CodeownersSearchScopeDescriptor(private val project: Project) : ScopeDescriptor(null) {
+    private val manager = project.service<CodeownersManager>()
+
+    private var cachedScope: SearchScope? = null
+
+    override fun getDisplayName(): String {
+        return CodeownersBundle.message("search.scope.name")
+    }
+
+    override fun getIcon() = CodeownersIcons.FILE
+
+    override fun scopeEquals(scope: SearchScope?): Boolean {
+        return cachedScope == scope
+    }
+
+    override fun getScope(): SearchScope? {
+        if (cachedScope == null) {
+            val codeownersFiles = manager.getCodeownersFiles().ifEmpty { return null }
+
+            val dialog = CodeownersSearchFilterDialog(project, codeownersFiles)
+
+            if (!dialog.showAndGet()) {
+                cachedScope = GlobalSearchScope.EMPTY_SCOPE
+                return null
+            }
+
+            val result = dialog.result!! // it cannot be null
+
+            val (codeownersFile, dnf) = result
+
+            cachedScope = CodeownersSearchScope(project, CodeownersSearchFilter(codeownersFile, DNF(dnf)))
+        }
+
+        return cachedScope
+    }
+}

--- a/src/main/kotlin/com/github/fantom/codeowners/search/CodeownersSearchScopeDescriptorProvider.kt
+++ b/src/main/kotlin/com/github/fantom/codeowners/search/CodeownersSearchScopeDescriptorProvider.kt
@@ -1,0 +1,12 @@
+package com.github.fantom.codeowners.search
+
+import com.intellij.ide.util.scopeChooser.ScopeDescriptor
+import com.intellij.ide.util.scopeChooser.ScopeDescriptorProvider
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.project.Project
+
+class CodeownersSearchScopeDescriptorProvider : ScopeDescriptorProvider {
+    override fun getScopeDescriptors(project: Project, dataContext: DataContext): Array<ScopeDescriptor> {
+        return arrayOf(CodeownersSearchScopeDescriptor(project))
+    }
+}

--- a/src/main/kotlin/com/github/fantom/codeowners/search/ui/CodeownersSearchFilterDialog.kt
+++ b/src/main/kotlin/com/github/fantom/codeowners/search/ui/CodeownersSearchFilterDialog.kt
@@ -1,0 +1,99 @@
+package com.github.fantom.codeowners.search.ui
+
+import com.github.fantom.codeowners.CodeownersManager
+import com.github.fantom.codeowners.indexing.CodeownersEntryOccurrence
+import com.github.fantom.codeowners.search.Filter
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.ComboBox
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.ui.CollectionComboBoxModel
+import com.intellij.ui.ScrollPaneFactory
+import java.awt.BorderLayout
+import java.awt.event.ItemEvent
+import javax.swing.BorderFactory
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+class CodeownersSearchFilterDialog(
+    project: Project,
+    codeownersFiles: List<CodeownersEntryOccurrence>, // must be not empty
+) : DialogWrapper(project) {
+    private var contentPane: JPanel
+    private var codeownersFileChooser = CodeownersFileChooser(codeownersFiles)
+
+    private var orsPanel: OrsPanel
+
+    var result: Pair<CodeownersEntryOccurrence, List<List<Filter>>>? = null
+    private set
+
+    private val manager = project.service<CodeownersManager>()
+
+    private fun getOwners() = codeownersFileChooser
+        .getChosenFile()
+        .let(manager::getMentionedOwners)
+
+    private fun createOrsPanel(): JPanel {
+        val container = JPanel().apply { layout = BorderLayout() }
+        container.add(orsPanel, BorderLayout.NORTH)
+        return container
+    }
+
+    init {
+        orsPanel = OrsPanel(getOwners())
+
+        val scrollPanel = ScrollPaneFactory.createScrollPane(createOrsPanel())
+
+        codeownersFileChooser.addItemListener {
+            if (it.stateChange == ItemEvent.SELECTED) {
+                orsPanel = OrsPanel(getOwners())
+                scrollPanel.setViewportView(createOrsPanel())
+                scrollPanel.revalidate()
+                scrollPanel.repaint()
+            }
+        }
+
+        // setup content panel
+        contentPane = JPanel().also { cp ->
+            cp.layout = BorderLayout() // to not let nested panels stretch vertically
+
+            cp.add(JPanel()
+                .also {
+                    it.layout = BorderLayout() // to make combobox stretch horizontally
+                    it.border = BorderFactory.createTitledBorder("Codeowners file")
+                    it.add(codeownersFileChooser)
+                },
+                BorderLayout.NORTH,
+            )
+            cp.add(scrollPanel, BorderLayout.CENTER)
+        }
+
+        init()
+    }
+
+    override fun doOKAction() {
+        result = Pair((codeownersFileChooser.getChosenFile()), orsPanel.getOrs())
+        super.doOKAction()
+    }
+
+    override fun createCenterPanel(): JComponent {
+        return contentPane
+    }
+}
+
+private class CodeownersFileChooser(
+    codeownersFiles: List<CodeownersEntryOccurrence>,
+): ComboBox<CodeownersFileChooser.CodeownersEntryOccurrenceWrapper>() {
+    init {
+        toolTipText = "Select a CODEOWNERS file used to calculate ownership"
+        model = CollectionComboBoxModel(codeownersFiles.map(::CodeownersEntryOccurrenceWrapper))
+    }
+
+    fun getChosenFile() = (selectedItem as CodeownersEntryOccurrenceWrapper).codeownersEntryOccurrence
+
+    class CodeownersEntryOccurrenceWrapper(val codeownersEntryOccurrence: CodeownersEntryOccurrence) {
+        override fun toString(): String {
+            return codeownersEntryOccurrence.url
+        }
+    }
+}

--- a/src/main/kotlin/com/github/fantom/codeowners/search/ui/CodeownersSearchFilterDialogPanels.kt
+++ b/src/main/kotlin/com/github/fantom/codeowners/search/ui/CodeownersSearchFilterDialogPanels.kt
@@ -1,0 +1,230 @@
+package com.github.fantom.codeowners.search.ui
+
+import com.github.fantom.codeowners.OwnersSet
+import com.github.fantom.codeowners.indexing.OwnerString
+import com.github.fantom.codeowners.search.Filter
+import com.github.fantom.codeowners.search.ui.FilterConditionType.*
+import com.intellij.openapi.ui.ComboBox
+import com.intellij.ui.CheckBoxList
+import com.intellij.ui.EnumComboBoxModel
+import com.intellij.ui.ScrollPaneFactory
+import com.intellij.ui.SimpleListCellRenderer
+import com.intellij.ui.components.JBCheckBox
+import java.awt.BorderLayout
+import java.awt.event.ItemEvent
+import javax.swing.*
+
+class OrsPanel(owners: OwnersSet) : JPanel() {
+    private val andsPanels = mutableListOf<AndsPanel>()
+
+    private var andsPanelsPanel: JPanel // contains ands panels and (+ or) button
+
+    private val addAndsButton: JButton
+
+    init {
+        layout = BoxLayout(this, BoxLayout.Y_AXIS) // we will have an unpredictable number of children
+        border = BorderFactory.createTitledBorder("Ors")
+
+        val andsPanel = createAndRegisterAndsPanel(owners)
+        this.add(andsPanel)
+
+        andsPanelsPanel = JPanel().apply {
+            layout = BoxLayout(this, BoxLayout.Y_AXIS) // we will have an unpredictable number of children
+        }
+        andsPanelsPanel.add(andsPanel, BorderLayout.NORTH)
+
+        add(andsPanelsPanel, BorderLayout.NORTH)
+
+        addAndsButton = createAndRegisterAddAndsButton(owners)
+        add(addAndsButton, BorderLayout.SOUTH)
+    }
+
+    private fun createAndRegisterAndsPanel(owners: OwnersSet): AndsPanel {
+        val andsPanel = AndsPanel(owners)
+        andsPanels.add(andsPanel)
+        return andsPanel
+    }
+
+    private fun createAndRegisterAddAndsButton(owners: OwnersSet): JButton {
+        val addAndsButton = JButton("+ (or)")
+
+        addAndsButton.addActionListener {
+            val andsPanel = createAndRegisterAndsPanel(owners)
+
+            val removeButton = JButton("x (remove)")
+            removeButton.addActionListener {
+                andsPanels.remove(andsPanel)
+
+                andsPanelsPanel.remove(andsPanel)
+                andsPanelsPanel.revalidate()
+                andsPanelsPanel.repaint()
+            }
+            andsPanel.add(removeButton, BorderLayout.SOUTH)
+
+            andsPanelsPanel.add(andsPanel)
+            andsPanelsPanel.revalidate()
+            andsPanelsPanel.repaint()
+        }
+
+        return addAndsButton
+    }
+
+    fun getOrs(): List<List<Filter>> = andsPanels.map(AndsPanel::getAnds)
+}
+
+class AndsPanel(owners: OwnersSet) : JPanel() {
+    private val filterPanels = mutableListOf<PrimitiveFilterPanel>()
+
+    private var filtersPanel: JPanel // contains filter panels and + (and) button
+
+    private val addFilterButton: JButton
+
+    init {
+        layout = BorderLayout() // don't let children stretch vertically
+        border = BorderFactory.createTitledBorder("Ands")
+
+        val filterPanel = createAndRegisterFilterPanel(owners)
+
+        filtersPanel = JPanel().apply {
+            layout = BoxLayout(this, BoxLayout.Y_AXIS) // we will have an unpredictable number of children
+        }
+        filtersPanel.add(filterPanel, BorderLayout.NORTH)
+
+        add(filtersPanel, BorderLayout.NORTH)
+
+        addFilterButton = createAndRegisterAddFilterButton(owners)
+        add(addFilterButton, BorderLayout.CENTER)
+    }
+
+    private fun createAndRegisterFilterPanel(owners: OwnersSet): PrimitiveFilterPanel {
+        val filterPanel = PrimitiveFilterPanel(owners)
+        filterPanels.add(filterPanel)
+        return filterPanel
+    }
+
+    private fun createAndRegisterAddFilterButton(owners: OwnersSet): JButton {
+        val addFilterButton = JButton("+ (and)")
+
+        addFilterButton.addActionListener {
+            val filterPanel = createAndRegisterFilterPanel(owners)
+
+            val removeButton = JButton("x (remove)")
+            removeButton.addActionListener {
+                filterPanels.remove(filterPanel)
+
+                filtersPanel.remove(filterPanel)
+                filtersPanel.revalidate()
+                filtersPanel.repaint()
+            }
+            filterPanel.add(removeButton)
+
+            filtersPanel.add(filterPanel, BorderLayout.NORTH)
+            filtersPanel.revalidate()
+            filtersPanel.repaint()
+        }
+
+        return addFilterButton
+    }
+
+    fun getAnds(): List<Filter> = filterPanels.map(PrimitiveFilterPanel::getFilter)
+}
+
+class PrimitiveFilterPanel(
+    owners: OwnersSet,
+) : JPanel() {
+    private val negationCheckbox = JBCheckBox("Not")
+
+    private val filterConditionComboBox = ComboBox(EnumComboBoxModel(FilterConditionType::class.java))
+
+    private val selectedOwnersIdxs = mutableSetOf<Int>()
+
+    private val ownersCheckBoxList = CheckBoxList<OwnerString>().apply {
+        setItems(owners.sorted(), null)
+        setCheckBoxListListener { idx, enabled ->
+            if (enabled) {
+                selectedOwnersIdxs.add(idx)
+            } else {
+                selectedOwnersIdxs.remove(idx)
+            }
+        }
+    }
+
+    private val ownersCheckBoxListScroll: JScrollPane
+
+    init {
+        layout = BoxLayout(this, BoxLayout.X_AXIS) // we have 2/3/4 children, placed in a row
+
+        ownersCheckBoxListScroll = ScrollPaneFactory.createScrollPane(ownersCheckBoxList).also {
+            // hide until user chooses compatible filter condition
+            it.isVisible = false
+        }
+
+        filterConditionComboBox.renderer = SimpleListCellRenderer.create("", FilterConditionType::title)
+        filterConditionComboBox.toolTipText = (filterConditionComboBox.selectedItem as FilterConditionType).description
+        filterConditionComboBox.addItemListener { e ->
+            if (e.stateChange == ItemEvent.SELECTED) {
+                val item = e.item as FilterConditionType
+                ownersCheckBoxListScroll.isVisible = !item.parameterless
+                filterConditionComboBox.toolTipText = item.description
+            }
+        }
+
+        // don't let combobox stretch vertically because of scroll pane
+        val container = JPanel().also {
+            it.layout = BoxLayout(it, BoxLayout.X_AXIS) // place checkbox and combobox in a row, let them stretch horizontally
+            it.add(negationCheckbox)
+            it.add(filterConditionComboBox)
+        }
+
+        val borderPanel = JPanel().also {
+            it.layout = BorderLayout()
+            it.add(container, BorderLayout.NORTH) // place panel with checkbox and combobox at the top of the panel, don't let it stretch vertically
+        }
+
+        add(borderPanel)
+        add(ownersCheckBoxListScroll)
+    }
+
+    fun getFilter(): Filter {
+        val condition = when (filterConditionComboBox.selectedItem as FilterConditionType) {
+            Unowned -> Filter.Condition.Unowned
+            OwnershipReset -> Filter.Condition.OwnershipReset
+            OwnedByAnyOf -> Filter.Condition.OwnedByAnyOf(selectedOwnersIdxs.map { ownersCheckBoxList.getItemAt(it)!! }.toSet())
+            OwnedByAllOf -> Filter.Condition.OwnedByAllOf(selectedOwnersIdxs.map { ownersCheckBoxList.getItemAt(it)!! }.toSet())
+            OwnedByExactly -> Filter.Condition.OwnedByExactly(selectedOwnersIdxs.map { ownersCheckBoxList.getItemAt(it)!! }.toSet())
+        }
+
+        return if (negationCheckbox.isSelected) {
+            Filter.Not(condition)
+        } else {
+            condition
+        }
+    }
+}
+
+private enum class FilterConditionType(
+    val parameterless: Boolean,
+    val title: String,
+    val description: String,
+) {
+    Unowned(true, "Unowned", "Files with no defined ownership"),
+    OwnershipReset(true, "Explicitly unowned", "Files with reset ownership"),
+    OwnedByAnyOf(false, "Owned by any of", "Files, owned by any of selected owners"),
+    OwnedByAllOf(false, "Owned by all of", "Files, owned by all selected owners"),
+    OwnedByExactly(false, "Owned by exactly", "Files, owned by only selected owners, nobody else"),
+    ;
+
+    companion object {
+        // for compile-time check, that we covered all filter types here
+        @Suppress("unused")
+        fun fromDomain(condition: Filter.Condition): FilterConditionType {
+            return when (condition) {
+                Filter.Condition.Unowned -> Unowned
+                Filter.Condition.OwnershipReset -> OwnershipReset
+                is Filter.Condition.OwnedByAnyOf -> OwnedByAnyOf
+                is Filter.Condition.OwnedByAllOf -> OwnedByAllOf
+                is Filter.Condition.OwnedByExactly -> OwnedByExactly
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/github/fantom/codeowners/util/CachedConcurrentMap.kt
+++ b/src/main/kotlin/com/github/fantom/codeowners/util/CachedConcurrentMap.kt
@@ -14,11 +14,9 @@ class CachedConcurrentMap<K: Any, V: Any> private constructor(private val fetche
         fun <K: Any, V: Any> create(fetcher: DataFetcher<K, V>) = CachedConcurrentMap(fetcher)
     }
 
-    operator fun get(key: K): V? {
-        if (!map.containsKey(key)) {
-            map[key] = fetcher.fetch(key)
-        }
-        return map[key]
+    operator fun get(key: K): V {
+        // fetcher doesn't return nulls
+        return map.computeIfAbsent(key) { fetcher.fetch(key) }
     }
 
     fun remove(key: K) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -157,6 +157,8 @@
                                implementationClass="com.github.fantom.codeowners.grouping.changes.CodeownersChangesGroupingPolicy$Factory"/>
         <usageGroupingRuleProvider implementation="com.github.fantom.codeowners.grouping.usage.CodeownersUsageGroupingRuleProvider"/>
         <applicationService serviceImplementation="com.github.fantom.codeowners.grouping.usage.CodeownersUsageViewSettings"/>
+
+        <scopeDescriptorProvider implementation="com.github.fantom.codeowners.search.CodeownersSearchScopeDescriptorProvider"/>
     </extensions>
 
     <actions>

--- a/src/main/resources/messages/CodeownersBundle.properties
+++ b/src/main/resources/messages/CodeownersBundle.properties
@@ -96,3 +96,4 @@ notification.group=.ignore plugin
 notification.group.update=.ignore plugin update information
 
 status.bar.codeowners.widget.name=Codeowners
+search.scope.name=File ownership


### PR DESCRIPTION
Closes #71 and #120 

This PR add an ability to filter files during search by their ownership
To do so, one needs to choose "File ownerhip" search scope from the dropdown and build a predicate.
<img width="431" alt="изображение" src="https://github.com/fan-tom/intellij-codeowners/assets/14140464/0b36e22e-4db4-421e-b9fd-697394e58146">
First, select a codeowners file, which will be used during filtration.
Then you need to build a predicate in a disjunctive normal form, aka disjunction of conjunctions. You can use a "Not" checkboxrs to invert your condition. Condition on the screenshot defines next predicate:
`(not unowned and not explicitly unowned) or (owned by (@doctocat or @github/group) and by @bar) or (owned by @bar and @doctocat)`, which, after simplification, gives `files with any owners, or owned by @doctocat and @bar or by @github/group and @bar`.
<img width="584" alt="изображение" src="https://github.com/fan-tom/intellij-codeowners/assets/14140464/2a522492-4c47-49c9-a874-caaaee9bcc09">
