### PR TITLE
Add support for IntelliJ 2024.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,11 +8,11 @@ pluginVersion = 0.7.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233
-pluginUntilBuild = 233.*
+pluginUntilBuild = 241.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC
-platformVersion = 2023.3
+platformVersion = 2024.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22


### PR DESCRIPTION
I updated to IntelliJ 2024.1 and it doesn't look like this plugin is compatible. I have a feeling this is just a configuration issue rather than a compatibility issue. I've bumped the versions in the configuration to get the plugin to load.