### PR TITLE
Use ActionUpdateThread.BGT to execute SetCodeownersChangesGroupingAction::update to prevent "Slow operations are prohibited on EDT: SetCodeownersChangesGroupingAction::update"

### DIFF
--- a/src/main/kotlin/com/github/fantom/codeowners/grouping/changes/SetCodeownersChangesGroupingAction.kt
+++ b/src/main/kotlin/com/github/fantom/codeowners/grouping/changes/SetCodeownersChangesGroupingAction.kt
@@ -1,12 +1,15 @@
 package com.github.fantom.codeowners.grouping.changes
 
 import com.github.fantom.codeowners.CodeownersManager
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.components.service
 import com.intellij.openapi.vcs.changes.actions.SetChangesGroupingAction
 
 class SetCodeownersChangesGroupingAction : SetChangesGroupingAction() {
     override val groupingKey: String get() = "codeowners"
+
+    override fun getActionUpdateThread() = ActionUpdateThread.BGT
 
     override fun update(e: AnActionEvent) {
         super.update(e)


### PR DESCRIPTION
Closes #297